### PR TITLE
Fix "Repoistory" typo in builder

### DIFF
--- a/app/domain/Protobox/Builder/Sections/Applications.php
+++ b/app/domain/Protobox/Builder/Sections/Applications.php
@@ -7,7 +7,7 @@ class Applications extends Section {
 	public function applications()
 	{
 		return [
-			'repository' => 'Git Repoistory (Public or Private)',
+			'repository' => 'Git Repository (Public or Private)',
 			'drupal' => 'Drupal',
 			'laravel' => 'Laravel',
 			'lemonstand' => 'Lemonstand',


### PR DESCRIPTION
"Repoistory" => "Repository"
